### PR TITLE
feat: use CBOR instead

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,6 +3,7 @@
   "version": "0.0.0",
   "description": "Simple DAG is a format for encoding data similar to JSON and CBOR but with a very different set of priorities.",
   "main": "index.js",
+  "type": "module",
   "scripts": {
     "test": "echo \"Error: no test specified\" && exit 1"
   },


### PR DESCRIPTION
Change the code with minimal changes to do CBOR encoding and decoding intead
of simple-dag. This should show that a CBOR parser that only supports DAG-CBOR
can also be implemented with very little code.

It is without encoding/decoding CIDs as this also doesn't work on master and
I didn't want to spend time fixing on it as this is really just a proof of
concept.